### PR TITLE
fix: fire compound interest w/ start balance

### DIFF
--- a/src/smarter-text.js
+++ b/src/smarter-text.js
@@ -54,6 +54,30 @@ function explainDecimal(d) {
   return { value: numeral(d).value(), formatString: formatString };
 }
 
+// Add custom functions to Parser
+
+// With compounding interest, calculate how many months it will take to reach a goal balance
+// Given a start balance, a monthly investment, and an annual interest rate
+// Also make it readable
+Exp.functions.monthsToGoalBalanceViaCompoundInterest = function (
+  startBalance,
+  goalBalance,
+  monthlyInvestment,
+  annualReturn
+) {
+  // Coerce to Numbers
+  var balance = Number(startBalance);
+  var endBalance = Number(goalBalance);
+  var monthlyAddition = Number(monthlyInvestment);
+  var monthlyRate = Number(annualReturn) / 12 / 100;
+  var monthsPassed = 0;
+  while (balance < endBalance) {
+    balance += balance * monthlyRate + monthlyAddition;
+    monthsPassed++;
+  }
+  return monthsPassed;
+};
+
 // Same as above, but we don't know value yet
 function makeExpression(parseResult, kind) {
   const [expression, variable] = parseResult;

--- a/src/texts/fire.txt
+++ b/src/texts/fire.txt
@@ -4,4 +4,5 @@ Your monthly take-home pay :dollar: is ${5000:monthlynet} and your monthly expen
 
 If you invest {=(100 / 4):multiple}x your annual expenses, or ${=multiple * (monthlyexpenses * 12):accumulationrequired}, a "safe" annual withdrawal rate of 4% :chart_with_downwards_trend: will cover :knife_fork_plate: :house: :pill: :car:.
 
-If you've already got ${10000:saved} invested :money_mouth:, at your savings rate plus a {6:return}% return, it will take {=(accumulationrequired - saved) / (((monthlynet - monthlyexpenses) * 12) + (((monthlynet - monthlyexpenses) * 12) + saved) * (return/100)):years} more years :older_adult: to build up enough enough :money_bag: quit working :wave: live on those returns :dancer: and achieve financial independence. :fire: :fire:
+If you've already got ${10000:saved} invested :money_mouth: and you're depositing ${=monthlynet-monthlyexpenses:monthlysavings} a month, at a {6:return}% annual return, it will take {=ceil(monthsToGoalBalanceViaCompoundInterest(saved, accumulationrequired, monthlysavings, return)/12):years} years :older_adult: to build up enough :money_bag: quit working :wave: live on those returns :dancer: and achieve financial independence. :fire: :fire: :fire:
+


### PR DESCRIPTION
Add a custom function that calculates how many months it will take
to reach a goal balance given compounding interest with a start balance,
monthly investments and an annual rate of return.

Call it in the fire calculator to calculate time till fire.